### PR TITLE
Fix "SyntaxWarning: invalid escape sequence '\s'"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setuptools import setup
 
 # Get the version string. Cannot be done with import!
 with open(os.path.join("intbitset", "intbitset_version.py"), "rt") as f:
-    version = re.search('__version__\s*=\s*"(?P<version>.*)"\n', f.read()).group("version")
+    version = re.search(r'__version__\s*=\s*"(?P<version>.*)"\n', f.read()).group("version")
 
 
 extra_compile_args = []


### PR DESCRIPTION
Fixes the build warning on Python 3.12 stating:

> SyntaxWarning: invalid escape sequence '\s'